### PR TITLE
Insert parameter for Viking's version in viking.xml

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -439,6 +439,7 @@ AC_CONFIG_FILES([
 		tools/Makefile
 		test/Makefile
 		help/Makefile
+		help/viking.xml
 		win32/Makefile
 		win32/installer/Makefile
 		win32/installer/pixmaps/Makefile

--- a/help/Makefile.am
+++ b/help/Makefile.am
@@ -53,7 +53,7 @@ DOC_FIGURES = \
     figures/customize_toolbar_dialog.png
 DOC_LINGUAS =
 
-EXTRA_DIST = viking.xml
+EXTRA_DIST = viking.xml.in
 
 CLEANFILES=
 # man pages processing

--- a/help/viking.xml.in
+++ b/help/viking.xml.in
@@ -31,9 +31,8 @@ and docbook-xsl in your Build-Depends control field.
   <!ENTITY dhsurname   "<surname>Meyer</surname>">
   <!-- Please adjust the date whenever revising the manpage. -->
   <!ENTITY dhdate      "<date>2015-03-29</date>">
-  <!-- Would be nice if the version could auto-update. -->
   <!ENTITY dhsource      "Viking">
-  <!ENTITY dhversion     "1.6.0">
+  <!ENTITY dhversion     "@PACKAGE_VERSION@">
   <!-- SECTION should be 1-8, maybe w/ subsection other parameters are
        allowed: see man(7), man(1). -->
   <!ENTITY dhsection   "<manvolnum>1</manvolnum>">


### PR DESCRIPTION
Insertion is done by configure, so the file is renamed as viking.xml.in.
The most annoying with this change is probably to configure the XML editor
to handle xml.in files.